### PR TITLE
[Fix]dropdown List 에서 overflow scrollbar 적용시 input 창 어그러짐

### DIFF
--- a/src/component/AutoComplete.js
+++ b/src/component/AutoComplete.js
@@ -170,7 +170,7 @@ const InputValueContainer = styled.div`
   align-items: center;
   margin-top: 7rem;
   width: 80%;
-  height: 13%;
+  min-height: 13%;
   border: 2px solid #e6e6e6;
   border-radius: ${(props) => (props.hasText ? '10px 10px 0 0' : '10px')};
 
@@ -219,6 +219,7 @@ const DropDownContainer = styled.ul`
   margin: 0;
   padding: 0;
   letter-spacing: -0.018em;
+  overflow: auto;
 
   > .dropdown-list {
     width: 98%;


### PR DESCRIPTION
드롭다운 영역에 overflow scroll이 적용되어도 input 영역 사이즈는 고정되어 있게 수정했습니다.

![Apr-13-2022 11-18-53](https://user-images.githubusercontent.com/87353284/163088506-0fa00b7c-370d-4c53-a44b-496411cf3894.gif)
