### PR TITLE
[Fix] AutoComplet 컴포넌트 dropdown List에서 마우스 hover상태에서 키보드 조작시 focus 문제

### DIFF
--- a/src/component/AutoComplete.js
+++ b/src/component/AutoComplete.js
@@ -92,8 +92,8 @@ export function AutoComplete({ subContainerBorder, handleSubContainerBorder }) {
     }
   };
 
-  const initializeSelectedIdx = () => {
-    setSelectedIdx(-1);
+  const handleMouseOver = (idx) => {
+    setSelectedIdx(idx);
   };
 
   return (
@@ -138,8 +138,8 @@ export function AutoComplete({ subContainerBorder, handleSubContainerBorder }) {
                     selectedIdx === idx ? 'select--focused' : ''
                   }`}
                   onClick={selectList}
-                  onMouseOver={initializeSelectedIdx}
-                  onFocus={initializeSelectedIdx}
+                  onMouseOver={() => handleMouseOver(idx)}
+                  onFocus={handleMouseOver}
                 >
                   {list}
                 </li>
@@ -229,12 +229,8 @@ const DropDownContainer = styled.ul`
     font-size: 1.2rem;
     cursor: pointer;
 
-    &:hover {
+    /* &:hover {
       background: #e6e6e6;
-    }
-
-    /* &:hover ~ .select--focused {
-      background: none;
     } */
 
     &.select--focused {


### PR DESCRIPTION
onMouseOver 이벤트의 콜백 함수의 인자로 현재 마우스가 위치한 리스트의 index를 전달하여 해당 index의 background 효과를 주는 방식으로 변경하였다. CSS 가상선택자 :hover 는 삭제 하였습니다.

아래의 그림을 보면 키보드 이동 후 마우스로 이동할 경우 focus 이동과
마우스 이동 후 키보드 조작으로 focus 이동 모두 잘 작동하는 것을 볼 수 있습니다.

<img src="https://user-images.githubusercontent.com/87353284/163102545-8365bd26-f4b3-4248-9546-2a75f8190928.gif" width="50%" />

기존코드 
```js
const initializeSelectedIdx = () => {
  setSelectedIdx(-1);
};

onMouseOver={() => initializeSelectedIdx}
onFocus={initializeSelectedIdx}

&:hover {
  background: #e6e6e6;
}
```

수정코드
```js
const handleMouseOver = (idx) => {
  setSelectedIdx(idx);
};

onMouseOver={() => handleMouseOver(idx)}
onFocus={handleMouseOver}

hover // 삭제
```
