### PR TITLE
[Fix]CarouselIdx에서 이미지 크기 변함

### DIFF
--- a/src/component/CarouselIdx.js
+++ b/src/component/CarouselIdx.js
@@ -25,7 +25,9 @@ export function CarouselIdx() {
           alt="없음"
         />
       </button>
-      <IMG src={dummySrc.image[currentImgIdx]} />
+      <ImgContainer>
+        <img src={dummySrc.image[currentImgIdx]} alt="없음" />
+      </ImgContainer>
       <button type="button" onClick={() => ImgHandler('plus')}>
         <img
           src="https://img.icons8.com/ios-glyphs/50/000000/double-right.png"
@@ -45,7 +47,7 @@ const WholeContainer = styled.div`
   height: 80%;
 
   > button {
-    margin: 10px;
+    margin: 5px;
     width: 50x;
     height: 50px;
     display: flex;
@@ -65,10 +67,14 @@ const WholeContainer = styled.div`
   }
 `;
 
-const IMG = styled.img`
-  object-fit: cover;
-  border: 1px solid #f2f2f2;
-  border-radius: 10px;
+const ImgContainer = styled.div`
   width: 200px;
   height: 275px;
+
+  img {
+    border: 1px solid #f2f2f2;
+    border-radius: 10px;
+    width: 100%;
+    height: 100%;
+  }
 `;


### PR DESCRIPTION
![Apr-19-2022 11-13-51](https://user-images.githubusercontent.com/87353284/163906488-7e5737aa-f45a-4d1a-b44d-3dc64626b824.gif)

이미지 전환 버튼을 눌려서 이미지가 변해도 
이미지의 크기는 고정되고 버튼의 위치 또한 변하지 않도록 수정했습니다.

해결방법
기존 img 태그만 있던 구조를 img위에 div 부모요소를 추가하였습니다.

기존 css 코드
```js
const IMG = styled.img`
  object-fit: cover;
  border: 1px solid #f2f2f2;
  border-radius: 10px;
  width: 200px;
  height: 275px;
```

수정 css 코드
```js
const ImgContainer = styled.div`
  width: 200px;
  height: 275px;

  img {
    border: 1px solid #f2f2f2;
    border-radius: 10px;
    width: 100%;
    height: 100%;
  }
```